### PR TITLE
Adicionar artigo agnóstico de testes unitários nas seções relacionadas à testes

### DIFF
--- a/_data/blocks/angular-testing.pt_BR.yaml
+++ b/_data/blocks/angular-testing.pt_BR.yaml
@@ -9,6 +9,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Testes de unidade usando Angular"
     link: https://medium.com/totvsdevelopers/testes-de-unidade-usando-angular-b83ea6accf7c
   - type: ARTICLE

--- a/_data/blocks/csharp-testing.pt_BR.yaml
+++ b/_data/blocks/csharp-testing.pt_BR.yaml
@@ -15,6 +15,9 @@ contents:
     title: "Microsoft Docs: Passo a passo: desenvolvimento controlado por teste usando o Gerenciador de Testes"
     link: https://docs.microsoft.com/pt-br/visualstudio/test/quick-start-test-driven-development-with-test-explorer?view=vs-2022
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Testes unitários em .NET com xUnit"
     link: https://medium.com/unicoidtech/testes-unit%C3%A1rios-em-net-com-xunit-d7c78c593832
   - type: ARTICLE

--- a/_data/blocks/java-testing.pt_BR.yaml
+++ b/_data/blocks/java-testing.pt_BR.yaml
@@ -9,6 +9,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Testes 101 — Testando aplicações Java"
     link: https://vepo.medium.com/testes-101-testando-aplica%C3%A7%C3%B5es-java-a12465319e61
   - type: ARTICLE

--- a/_data/blocks/javascript-testing.pt_BR.yaml
+++ b/_data/blocks/javascript-testing.pt_BR.yaml
@@ -9,6 +9,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Uma visão geral de testes em Javascript"
     link: https://medium.com/devzera/uma-vis%C3%A3o-geral-de-testes-em-javascript-em-2018-8484154caf63
   - type: ARTICLE

--- a/_data/blocks/jest.pt_BR.yaml
+++ b/_data/blocks/jest.pt_BR.yaml
@@ -5,6 +5,9 @@ key-objectives:
   - Testar componentes
 aditional-objectives:
 contents:
+  - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
   - type: SITE
     title: "Jest: Documentação"
     link: https://jestjs.io/pt-BR/docs/getting-started

--- a/_data/blocks/nodejs-testing.pt_BR.yaml
+++ b/_data/blocks/nodejs-testing.pt_BR.yaml
@@ -10,6 +10,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Anatomia de um teste em JavaScript"
     link: https://gabrieluizramos.com.br/anatomia-de-um-teste-em-javascript
   - type: ARTICLE

--- a/_data/blocks/php-testing.pt_BR.yaml
+++ b/_data/blocks/php-testing.pt_BR.yaml
@@ -9,6 +9,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Testes unitários com PHP 7"
     link: https://medium.com/@bernardoamaral/testes-unit%C3%A1rios-com-php-7-b018164cd284
   - type: ARTICLE

--- a/_data/blocks/python-testing.pt_BR.yaml
+++ b/_data/blocks/python-testing.pt_BR.yaml
@@ -12,6 +12,9 @@ contents:
     title: "Documentação Python - Framework de Testes Unitários"
     link: https://docs.python.org/pt-br/dev/library/unittest.html
   - type: ARTICLE
+    title: "Testes Unitários: Fundamentos e Qualidade de Software!"
+    link: https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0
+  - type: ARTICLE
     title: "Tutorial: Testes Unitários e Python — Parte I"
     link: https://medium.com/mercos-engineering/tutorial-testes-unit%C3%A1rios-e-python-parte-i-bb77182db93f
   - type: ARTICLE


### PR DESCRIPTION
Fala pessoal! 

Queria deixar uma pequena contribuição com o projeto sugerindo a inclusão de um artigo que escrevi há pouco tempo sobre [Testes Unitários: Fundamentos e Qualidade de Software!](https://dev.to/wnqueiroz/testes-unitarios-fundamentos-e-qualidade-de-software-5af0).

A alteração adiciona o artigo nas seções de testes dentre os "paths" que acredito que faça sentido.

cc @omariosouto 