### PR TITLE
correção de links no card de JavaScript - Modularização 

### DIFF
--- a/_data/blocks/javascript-modularization.pt_BR.yaml
+++ b/_data/blocks/javascript-modularization.pt_BR.yaml
@@ -17,10 +17,10 @@ contents:
     link: https://gabrieluizramos.com.br/modulos-em-javascript
   - type: YOUTUBE
     title: "Evandro Falleiros: Introdução à POO com JS - Modularização e importações"
-    link: https://www.youtube.com/watch?v=wzdKc0AFY6k&list=PLGxZ4Rq3BOBoSRcKWEdQACbUCNWLczg2G&index=51
+    link: https://www.youtube.com/watch?v=KL0qEMbTYFE
   - type: YOUTUBE
     title: "Professor Edson Maia: JS OO Modularizar o código import e export"
-    link: https://www.youtube.com/watch?v=8OHoAZ6j0Rg&list=PLGxZ4Rq3BOBoSRcKWEdQACbUCNWLczg2G&index=52
+    link: https://www.youtube.com/watch?v=RMK5WdPGWDU
 alura-contents:
   - type: ARTICLE
     title: "Um guia para importação e exportação de módulos com JavaScript"


### PR DESCRIPTION
No card de JavaScript - Modularização, os links para o youtube das opções: 

- Evandro Falleiros: Introdução à POO com JS - Modularização e importações
- Professor Edson Maia: JS OO Modularizar o código import e export

estavam redirecionando para um endereço icorreto.