### PR TITLE
Correções de espaçamento na home

### DIFF
--- a/src/patterns/Footer/index.tsx
+++ b/src/patterns/Footer/index.tsx
@@ -49,7 +49,7 @@ export default function Footer() {
         <Box
           styleSheet={{
             flex: 1,
-            paddingLeft: "1em",
+            padding: "0 1em",
             fontSize: "0.75rem",
             fontWeight: "600",
             lineHeight: "1.5",

--- a/src/patterns/ScreenHeroContainer/patterns/SecondContentSection/index.tsx
+++ b/src/patterns/ScreenHeroContainer/patterns/SecondContentSection/index.tsx
@@ -13,6 +13,7 @@ export default function SecondContentSection() {
         color: "#fff",
         paddingTop: {
           md: "3.5em",
+          lg: "4.5em",
         },
         alignItems: "center",
       }}
@@ -28,7 +29,10 @@ export default function SecondContentSection() {
             xs: "initial",
             md: "580px",
           },
-          paddingTop: "3.5em",
+          paddingTop: {
+            xs: "3.5em",
+            md: "0",
+          },
           paddingHorizontal: {
             xs: "1.875rem",
           },
@@ -54,6 +58,8 @@ export default function SecondContentSection() {
           className="container--flexbox"
           styleSheet={{
             alignItems: "center",
+            margin: { xs: "0", md: "0 0 4.5em", lg: "0" },
+            padding: { lg: "0" },
           }}
         >
           <Text


### PR DESCRIPTION
Pequenas correções de espaçamento na home. A primeira é na section de discover, que atualmente está assim:

![image](https://user-images.githubusercontent.com/1522117/190225935-c02fddcd-3552-4c8b-adee-f045552edb71.png)

Com a correção, fica assim:

![image](https://user-images.githubusercontent.com/1522117/190226029-7e350b67-b791-4b0d-8fb4-8f123c2e6ee6.png)

Quanto a correção no rodapé, foi apontado ao time de dev que o espaçamento do texto no mobile (especificamente tamanhos 390px) fica assim:

![image](https://user-images.githubusercontent.com/1522117/190226176-d74dd03b-9aba-477b-ae1f-b37bcb6be472.png)

Com a correção, temos padding na direita também, impedindo que o texto fique grudado na aresta da página

![image](https://user-images.githubusercontent.com/1522117/190226314-6d52a513-bea8-424f-93c4-a44c2f1454ad.png)
