### PR TITLE
style: efeito sanfona no FAQ mais suave

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -3,6 +3,7 @@ import BaseComponent from "@src/theme/BaseComponent";
 import { StyleSheet } from "@skynexui/responsive_stylesheet";
 
 interface BoxProps {
+  id?: string;
   tag?: "main" | "div" | "article" | "section" | "ul" | string;
   children?: React.ReactNode;
   className?: string;

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -12,6 +12,8 @@ interface BoxProps {
   xmlns?: string;
   // eslint-disable-next-line no-unused-vars
   onClick?: (event: any) => void;
+  // eslint-disable-next-line no-unused-vars
+  onFocus?: (event: any) => void;
 }
 const Box = React.forwardRef(
   ({ styleSheet, children, tag, ...props }: BoxProps, ref) => {

--- a/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
+++ b/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
@@ -191,7 +191,7 @@ function FAQQuestion({ title, description }: any) {
           overflow: "auto",
         }}
         aria-hidden={isOpen ? "false" : "true"}
-        onFocus={() => setIsOpen(true)} // Open in case a link inside the accordion is focused by keyboard navigation
+        onFocus={() => setIsOpen(true)}
       >
         <Text
           styleSheet={{

--- a/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
+++ b/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
@@ -191,6 +191,7 @@ function FAQQuestion({ title, description }: any) {
           overflow: "auto",
         }}
         aria-hidden={isOpen ? "false" : "true"}
+        onFocus={() => setIsOpen(true)} // Open in case a link inside the accordion is focused by keyboard navigation
       >
         <Text
           styleSheet={{

--- a/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
+++ b/src/patterns/ScreenHeroContainer/patterns/FAQContentSection/index.tsx
@@ -148,6 +148,8 @@ function FAQQuestion({ title, description }: any) {
           },
         }}
         onClick={() => setIsOpen(!isOpen)}
+        aria-controls={title}
+        aria-expanded={isOpen ? "true" : "false"}
       >
         <Text>
           {title}
@@ -163,6 +165,7 @@ function FAQQuestion({ title, description }: any) {
               width: "18px",
               height: "11px",
               transform: `rotate(${isOpen ? "0deg" : "180deg"})`,
+              transition: "transform .4s ease-out",
             }}
           >
             <path
@@ -175,12 +178,19 @@ function FAQQuestion({ title, description }: any) {
         </Text>
       </Box>
       <Box
+        id={title}
         styleSheet={{
-          display: isOpen ? "flex" : "none",
+          display: "flex",
           flex: 1,
           width: "100%",
           marginBottom: "24px",
+          transition: `max-height 0.5s ${
+            isOpen ? "ease-in-out" : "cubic-bezier(0, 1, 0, 1)"
+          }`,
+          maxHeight: isOpen ? "1000px" : 0,
+          overflow: "auto",
         }}
+        aria-hidden={isOpen ? "false" : "true"}
       >
         <Text
           styleSheet={{


### PR DESCRIPTION
### Issue referenciada
#21 

### Exemplo
Desktop
![accordion-desktop](https://user-images.githubusercontent.com/8469440/190464580-26ed4304-9496-4dcf-90fd-e9a6e9948319.gif)


Mobile
![accordion-mobile](https://user-images.githubusercontent.com/8469440/190464637-77ebd4c8-17ae-4f52-8b7e-c47e3d05c9fc.gif)


### Problemas dessa implementação
Como estou escondendo o conteúdo apenas com `aria-hidden` e `height: 0`, os links que estão encolhidos dentro do FAQ ainda podem ser navegáveis por teclado, o que é meio estranho.

A solução mais simples pra isso seria abrir o acordeão caso o algum elemento focável dentro do acordeão fosse selecionado, mesmo com ele fechado. `onFocus={() => setIsOpen(true)}`, que foi o que fiz.

Se quisermos que os links sejam inacessíveis por teclado quando o acordeão estiver fechado precisamos gerenciar o estado da animação e quando ela terminar adicionar um `display: none` no conteúdo, mas eu acho que aumenta muito a complexidade do componente.

Que vocês acham?