### PR TITLE
Extensões recomendadas para VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig"]
+}


### PR DESCRIPTION
### Alterações

Adiciona o arquivo `.vscode/extensions.json` ao projeto.

O Vscode lê esse arquivo e mostra um popup pra usuária que abra o projeto e não tenha as extensões instaladas. Isso na minha opinião melhora e experiência pra usuária que quer contribuir pro projeto pela primeira vez, e pode ajudar a evitar problemas como aconteceu no [PR#31](https://github.com/alura/techguide/pull/31#issuecomment-1248296637)

<img width="400" alt="Screenshot 2022-09-17 at 14 51 18" src="https://user-images.githubusercontent.com/8469440/190870140-43c53192-59ce-46a0-9d2a-e3a979a169f8.png">

[Mais informações sobre o arquivo extensions.json](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions)