### PR TITLE
Fix: nome do job no arquivo continuous-delivery.yml

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,7 +8,7 @@ env:
   DEPLOY_MAIN_WEBHOOK: ${{ secrets.DEPLOY_MAIN_WEBHOOK }}
 
 jobs:
-  test:
+  deploy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Estava me baseando nos workflows definidos no projeto para configurar um projeto pessoal.

Vi que o último commit na `main` tinha a marcação do job `test` executado com referência pra ele, porém o arquivo `continuous-integration.yml` que configura o job `test` só acontece em PRs:

<img width="913" alt="Commit na branch main com job test executado" src="https://user-images.githubusercontent.com/31140984/190878303-8bb49037-aab2-4b10-8088-e76a9244e07b.png">

Depois de uns minutinhos entendi que era o nome do job de deploy que estava como `test`.

É um detalhe bem pequeno e simples mas que se corrigido evita que isso aconteça com outras pessoas.