### PR TITLE
Removing a Javascript article link from Java Error Handling Recommendation block

### DIFF
--- a/_data/blocks/pt_BR/java-error-handling.pt_BR.yaml
+++ b/_data/blocks/pt_BR/java-error-handling.pt_BR.yaml
@@ -19,9 +19,6 @@ contents:
     link: https://www.youtube.com/watch?v=ld2C4GcAtsg
 alura-contents:
   - type: ARTICLE
-    title: "Exceções e Erros em JavaScript"
-    link: http://gabrielprates.com/2017/06/02/excecoes-e-erros-em-js.html
-  - type: ARTICLE
     title: "Evite o NullPointerException no Java"
     link: https://www.alura.com.br/artigos/evite-o-nullpointerexception-no-java
   - type: SITE

--- a/_data/blocks/pt_BR/java-errorhandling.pt_BR.yaml
+++ b/_data/blocks/pt_BR/java-errorhandling.pt_BR.yaml
@@ -19,9 +19,6 @@ contents:
     link: https://www.youtube.com/watch?v=ld2C4GcAtsg
 alura-contents:
   - type: ARTICLE
-    title: "Exceções e Erros em JavaScript"
-    link: http://gabrielprates.com/2017/06/02/excecoes-e-erros-em-js.html
-  - type: ARTICLE
     title: "Evite o NullPointerException no Java"
     link: https://www.alura.com.br/artigos/evite-o-nullpointerexception-no-java
   - type: SITE


### PR DESCRIPTION
Removing a Javascript article link from the Java Error Handling Recommendation block