### PR TITLE
Corrigido link do Curso Linux II: programas, processos e pacotes, onde estava direcionando para a tela principal do alura e não para ao do curso

### DIFF
--- a/_data/cards/pt_BR/linux-fundamentals.yaml
+++ b/_data/cards/pt_BR/linux-fundamentals.yaml
@@ -51,7 +51,7 @@ alura-contents:
     link: https://cursos.alura.com.br/course/linux-ubuntu
   - type: COURSE
     title: "Curso Linux II: programas, processos e pacotes"
-    link: https://www.alura.com.br/curso-online-linux-ubuntu-processos
+    link: https://cursos.alura.com.br/course/linux-ubuntu-processos
   - type: COURSE
     title: "Linux Onboarding: usando a CLI de uma forma rápida e prática"
     link: https://cursos.alura.com.br/course/linux-onboarding-utilizar-cli-forma-rapida-pratica


### PR DESCRIPTION
Corrigido link do Curso Linux II: programas, processos e pacotes, onde estava direcionando para a tela principal do alura e não para ao do curso