### PR TITLE
Adiciona o card de micro frontends no guia de Frontend

### DIFF
--- a/_data/cards/pt_BR/micro-frontend.yaml
+++ b/_data/cards/pt_BR/micro-frontend.yaml
@@ -1,0 +1,36 @@
+name: Micro Frontends
+logo:
+short-description:
+key-objectives:
+  - Micro Frontends são uma abordagem arquitetural na qual uma aplicação web é dividida em partes independentes, cada uma representando uma parte específica da interface do usuário.
+  - Divide uma aplicação web em partes independentes, facilitando o desenvolvimento e a manutenção.
+  - Possibilita a implantação e atualização contínua de partes específicas da aplicação sem afetar o aplicativo como um todo.
+  - Permite que equipes trabalhem de forma independente em diferentes partes da aplicação.
+  - Integra diferentes tecnologias e frameworks para desenvolver microfrontends, como React, Angular, Vue.js, entre outros.
+aditional-objectives:
+contents:
+  - type: ARTICLE
+    title: "Micro Frontends"
+    link: https://medium.com/@lorenamelor/micro-frontends-ac0e5d87582a
+  - type: ARTICLE
+    title: "O poder dos Micro-Frontends: Uma abordagem moderna para a Arquitetura Frontend"
+    link: https://aws.amazon.com/pt/blogs/aws-brasil/o-poder-dos-micro-frontends-uma-abordagem-moderna-para-a-arquitetura-frontend/
+  - type: YOUTUBE
+    title: "Implementando micro front-end com Single SPA e React"
+    link: https://youtu.be/68LaXOWwxZI?si=PM2te6z9l1QymshI
+alura-contents:
+  - type: PODCAST
+    title: "Microfrontends – Hipsters #164"
+    link: https://www.hipsters.tech/microfrontends-hipsters-164/
+  - type: PODCAST
+    title: "Micro Frontends na Conta Azul – Hipsters On The Road #26"
+    link: https://www.hipsters.tech/micro-frontends-no-conta-azul-hipsters-on-the-road-26/
+  - type: SITE
+    title: "Plurall e a Evolução da Arquitetura Front-End"
+    link: https://cursos.alura.com.br/extra/cases/plurall-e-a-evolucao-da-arquitetura-front-end-z1064
+  - type: SITE
+    title: "Klarna e a Evolução da Arquitetura Front-End"
+    link: https://cursos.alura.com.br/extra/cases/klarna-e-a-evolucao-da-arquitetura-front-end-z1283
+  - type: SITE
+    title: "Idwall e a Evolução da stack de Javascript"
+    link: https://cursos.alura.com.br/extra/cases/idwall-e-a-evolucao-da-stack-de-javascript-z1290

--- a/_data/guides/pt_BR/front-end.yaml
+++ b/_data/guides/pt_BR/front-end.yaml
@@ -1,9 +1,9 @@
 name: Front-end
-tags: 
+tags:
   - front-end
 expertise:
   - name: Front-end JavaScript Jr
-    cards: 
+    cards:
       - html-fundamentals:
         priority: 10
       - css-fundamentals:
@@ -56,6 +56,9 @@ expertise:
       - apollo-client:
         priority: 5
         optional: true
+      - micro-frontend:
+        priority: 5
+        optional: true
 collaboration:
   - name: Infraestrutura e Back-end
     cards:
@@ -65,9 +68,9 @@ collaboration:
         priority: 10
       - json:
         priority: 8
-      - command-line-fundamentals: 
+      - command-line-fundamentals:
         priority: 7
-      - cloud-fundamentals: 
+      - cloud-fundamentals:
         priority: 6
         optional: true
       - yarn:


### PR DESCRIPTION
## Adiciona Card de Micro Frontends no Guia de Frontend

Adicionei um card sobre Micro Frontends ao nosso guia de Frontend. Isso vai enriquecer nosso conteúdo visto que aproveitei para inserir os links dos cases que temos na plataforma com grandes empresas que usam essa solução nos seus negócios. Também faz parte de uma meta da escola de Frontend essa adição.

Por favor, revise e compartilhe qualquer feedback. Estou aberto a ajustes!

Alterações Propostas:

- Adiciona o card sobre Micro Frontends ao guia de Frontend.

Aguardando o seu feedback! 🚀