### PR TITLE
Correção de erros no Tech Guide de Kotlin

### DIFF
--- a/_data/guides/pt_BR/kotlin-backend.yaml
+++ b/_data/guides/pt_BR/kotlin-backend.yaml
@@ -16,8 +16,6 @@ expertise:
         priority: 8
       - kotlin-extensions:
         priority: 8
-      - java-functional-programming:
-        priority: 7
   - name: Kotlin Back-end Mid
     cards:
       - jvm:


### PR DESCRIPTION
Card `java-functional-programming` não existe mais.