### PR TITLE
Correção do Tech Guide de Kotlin

### DIFF
--- a/_data/guides/pt_BR/kotlin-backend.yaml
+++ b/_data/guides/pt_BR/kotlin-backend.yaml
@@ -53,8 +53,6 @@ collaboration:
           priority: 9
         - http-fundamentals:
           priority: 10
-        - test-driven-development:
-          priority: 7
         - design-patterns:
           priority: 6
         - json:


### PR DESCRIPTION
O card `test-driven-development` não existe mais.