### PR TITLE
feat: organiza ordem dos links e atualiza link de curso

### DIFF
--- a/_data/cards/pt_BR/javascript-callbacks-promises.yaml
+++ b/_data/cards/pt_BR/javascript-callbacks-promises.yaml
@@ -13,6 +13,9 @@ key-objectives:
 aditional-objectives:
 contents:
   - type: SITE
+    title: "MDN Web Docs: Introdução ao JavaScript Async"
+    link: https://developer.mozilla.org/pt-BR/docs/Learn/JavaScript/Asynchronous/Introducing
+  - type: SITE
     title: "MDN Web Docs: Funções assíncronas"
     link: https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Statements/async_function
   - type: SITE
@@ -21,9 +24,6 @@ contents:
   - type: SITE
     title: "MDN Web Docs: Função Callback"
     link: https://developer.mozilla.org/pt-BR/docs/Glossary/Callback_function
-  - type: SITE
-    title: "MDN Web Docs: Introdução ao JavaScript Async"
-    link: https://developer.mozilla.org/pt-BR/docs/Learn/JavaScript/Asynchronous/Introducing
   - type: YOUTUBE
     title: "Mario Souto - Dev Soutinho: Como usar Async/Await? Promises no JavaScript?"
     link: https://www.youtube.com/watch?v=q28lfkBd9F4
@@ -47,5 +47,5 @@ alura-contents:
     title: "Alura+: JavaScript assíncrono e Fetch"
     link: https://cursos.alura.com.br/extra/alura-mais/javascript-assincrono-e-fetch-c93
   - type: COURSE
-    title: "Curso Node.js: criando sua primeira biblioteca"
-    link: https://cursos.alura.com.br/course/nodejs-criando-primeira-biblioteca
+    title: "Curso JavaScript: consumindo e tratando dados de uma API"
+    link: https://cursos.alura.com.br/course/javascript-consumindo-tratando-dados-uma-api


### PR DESCRIPTION
- Link introdutório da documentação do MDN movido para o início
- Link do curso de Node.js substituído pelo link do curso de Front-end