### PR TITLE
docs: Adiciona conteúdo sobre swiftUi no guia de iOS

### DIFF
--- a/_data/cards/pt_BR/ios-swiftui.yaml
+++ b/_data/cards/pt_BR/ios-swiftui.yaml
@@ -24,9 +24,12 @@ contents:
     title: "(Playlist) Como Criar Um Aplicativo iOS completo (e simples) com SwiftUI | Tiago Aguiar"
     link: https://www.youtube.com/watch?v=Gt75k60tMjc&list=PLJ0AcghBBWSgknzUhjYpPkLiIjk4Ny3WF
 alura-contents:
-  - type: COURSE
-    title: "Formação: Construa aplicativos iOS com SwiftUI"
-    link: https://cursos.alura.com.br/formacao-ios-swiftui
   - type: ARTICLE
     title: "Vale a pena aprender SwiftUI hoje?"
     link: https://www.alura.com.br/artigos/vale-a-pena-aprender-swift-ui-hoje
+  - type: COURSE
+    title: "Formação: Construa aplicativos iOS com SwiftUI"
+    link: https://cursos.alura.com.br/formacao-ios-swiftui
+  - type: COURSE
+    title: "Formação Evolua Apps em SwiftUI: CRUD, MVVM e Autenticação"
+    link: https://www.alura.com.br/formacao-apps-swiftui-crud-mvvm-autenticacao


### PR DESCRIPTION
# Adiciona conteúdo sobre swiftUi no guia de iOS

Adiciona novos conteúdos da plataforma Alura no guia de Swift.

Agradeço pela revisão! Qualquer feedback é bem-vindo.