### PR TITLE
Add "Séries temporais com Prophet"

### DIFF
--- a/_data/cards/pt_BR/statistics-and-math-fundamentals.yaml
+++ b/_data/cards/pt_BR/statistics-and-math-fundamentals.yaml
@@ -50,3 +50,6 @@ alura-contents:
   - type: BOOK
     title: "Introdução à Estatística para Ciência de Dados: Da exploração dos dados à experimentação contínua com exemplos de código em Python e R"
     link: https://www.casadocodigo.com.br/products/livro-estatistica-datascience
+  - type: BOOK
+    title: "Séries temporais com Prophet: Análise e previsão de dados com Python"
+    link: https://www.casadocodigo.com.br/products/livro-series-temporais-prophet


### PR DESCRIPTION
Como o card indica o conteúdo de Séries Temporais, como objetivo de aprendizado, é ideal manter a obra como indicação.

