### PR TITLE
Adicionando card ao guide de Angular

### DIFF
--- a/_data/guides/pt_BR/angular.yaml
+++ b/_data/guides/pt_BR/angular.yaml
@@ -51,6 +51,8 @@ expertise:
       - apollo-client:
         priority: 5
         optional: true
+      - angular-design-system:
+        priority: 5
 collaboration:
   - name: Infraestrutura e Back-end
     cards:


### PR DESCRIPTION
Adicionando o card "angular-design-system" ao guide de Angular no nível de profundidade 3 do Tech Guide.