### PR TITLE
Corrigindo o link do vídeo do Lucas Caton

### DIFF
--- a/_data/cards/pt_BR/shell-scripting.yaml
+++ b/_data/cards/pt_BR/shell-scripting.yaml
@@ -13,7 +13,7 @@ contents:
     link: https://diolinux.com.br/tecnologia/o-que-e-shell-script.html
   - type: YOUTUBE
     title: "Lucas Caton: Como criar scripts no Linux e no macOS"
-    link: https://www.youtube.com/watch?v=SPwyp2NG-bE
+    link: https://www.youtube.com/watch?v=W84Ok6XGnow
   - type: YOUTUBE
     title: "NetworkChuck: BASH Scripting"
     link: https://www.youtube.com/watch?v=SPwyp2NG-bE


### PR DESCRIPTION
Estava acompanhando os conteúdos e percebi que o link do vídeo **NetworkChuck: BASH Scripting** estava duplicado e não existia a referência correta para o vídeo **Lucas Caton: Como criar scripts no Linux e no macOS**.

Adicionei o link que acredito ter sido recomendado. 😄 